### PR TITLE
Ignore _trackingId with -1 value

### DIFF
--- a/tasks/adapt_insert_tracking_ids.js
+++ b/tasks/adapt_insert_tracking_ids.js
@@ -24,11 +24,11 @@ module.exports = function(grunt) {
                     block._trackingId = ++options._latestTrackingId;
                     grunt.log.writeln("Adding tracking ID: " + block._trackingId + " to block " + block._id);
                 } else {
-                    if(options._trackingIdsSeen.indexOf(block._trackingId) > -1) {
+                    if(block._trackingId != -1 && options._trackingIdsSeen.indexOf(block._trackingId) > -1) {
                         grunt.log.writeln("Warning: " + block._id + " has the tracking ID " + block._trackingId + ", but this is already in use. Changing to " + (options._latestTrackingId + 1) + ".");
                         block._trackingId = ++options._latestTrackingId;
                     } else {
-                        options._trackingIdsSeen.push(block._trackingId);
+                        if(block._trackingId != -1) options._trackingIdsSeen.push(block._trackingId);
                     }
                 }
                 if(options._latestTrackingId < block._trackingId) {

--- a/tasks/adapt_remove_tracking_ids.js
+++ b/tasks/adapt_remove_tracking_ids.js
@@ -15,7 +15,8 @@ module.exports = function(grunt) {
         function removeTrackingIds(blocks, course){
             
             for(var i = 0; i < blocks.length; i++) {
-                delete blocks[i]._trackingId;
+                if(blocks[i]._trackingId != -1)
+                    delete blocks[i]._trackingId;
             }
             delete course._latestTrackingId;
             grunt.log.writeln("Tracking IDs removed.");

--- a/tasks/adapt_reset_tracking_ids.js
+++ b/tasks/adapt_reset_tracking_ids.js
@@ -20,9 +20,11 @@ module.exports = function(grunt) {
             
             for(var i = 0; i < blocks.length; i++) {
                 var block = blocks[i];
-                block._trackingId = ++options._latestTrackingId;
-                grunt.log.writeln("Adding tracking ID: " + block._trackingId + " to block " + block._id);
-                options._latestTrackingId = block._trackingId;
+                if(block._trackingId != -1) {
+                    block._trackingId = ++options._latestTrackingId;
+                    grunt.log.writeln("Adding tracking ID: " + block._trackingId + " to block " + block._id);
+                    options._latestTrackingId = block._trackingId;
+                }
             }
             course._latestTrackingId = options._latestTrackingId;
             grunt.log.writeln("The latest tracking ID is " + course._latestTrackingId);


### PR DESCRIPTION
This ignores blocks with `_trackingId` equal to '-1'. Which is useful when one tries to exclude blocks from tracking.
